### PR TITLE
feat: enhance styling with light and dark theme

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,7 @@
   --color-accent: #f59e42;
   --color-background: #f9fafb;
   --color-foreground: #171717;
-  --font-family-sans: 'Inter', Arial, Helvetica, sans-serif;
+  --font-family-sans: "Inter", Arial, Helvetica, sans-serif;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -40,7 +40,7 @@ a {
 
 /* カードデザイン */
 .card {
-  @apply bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 border border-gray-100;
+  @apply bg-white rounded-xl shadow-md hover:shadow-lg transition-shadow duration-300 border border-gray-100 dark:bg-gray-800 dark:border-gray-700;
 }
 
 /* --- ブログ記事のproseカスタマイズ --- */
@@ -60,22 +60,24 @@ a {
   @apply text-xl font-semibold text-primary mt-4 mb-2;
 }
 .prose p {
-  @apply text-lg leading-8 text-gray-800 mb-6;
+  @apply text-lg leading-8 text-gray-800 mb-6 dark:text-gray-200;
 }
 .prose a {
   @apply text-primary underline hover:text-primary-dark;
 }
 .prose blockquote {
-  @apply border-l-4 border-primary bg-blue-50 text-primary-dark italic px-6 py-4 rounded-lg my-6;
+  @apply border-l-4 border-primary bg-blue-50 text-primary-dark italic px-6 py-4 rounded-lg my-6 dark:bg-gray-800 dark:text-gray-100 dark:border-gray-700;
 }
 .prose code {
   @apply text-accent bg-gray-100 px-2 py-1 rounded;
 }
-.prose ul > li::marker, .prose ol > li::marker {
+.prose ul > li::marker,
+.prose ol > li::marker {
   color: var(--color-primary);
 }
 
 /* ヘッダー・フッターの配色統一 */
-header, footer {
-  @apply bg-primary-dark text-white;
+header,
+footer {
+  @apply bg-gradient-to-r from-primary-dark via-primary to-accent text-white dark:from-gray-900 dark:via-gray-800 dark:to-gray-700 dark:text-gray-200;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,36 +1,37 @@
-import type { Metadata } from 'next'
-import { Inter } from 'next/font/google'
-import './globals.css'
-import Header from '@/components/Header'
-import Footer from '@/components/Footer'
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
 
-const inter = Inter({ subsets: ['latin'] })
+const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: {
-    default: 'DX・業務効率化情報サイト',
-    template: '%s | DX・業務効率化情報サイト',
+    default: "DX・業務効率化情報サイト",
+    template: "%s | DX・業務効率化情報サイト",
   },
-  description: '自治体職員・公務員向けのDX、業務効率化、条例改正、契約知識に関する専門情報を提供',
-  keywords: ['DX', '業務効率化', '条例改正', '契約知識', '自治体', '公務員'],
-}
+  description:
+    "自治体職員・公務員向けのDX、業務効率化、条例改正、契約知識に関する専門情報を提供",
+  keywords: ["DX", "業務効率化", "条例改正", "契約知識", "自治体", "公務員"],
+};
 
 export default function RootLayout({
   children,
 }: {
-  children: React.ReactNode
+  children: React.ReactNode;
 }) {
   return (
     <html lang="ja">
-      <body className={`${inter.className} antialiased`}>
+      <body
+        className={`${inter.className} antialiased bg-background text-foreground dark:bg-gray-900 dark:text-gray-100`}
+      >
         <div className="min-h-screen flex flex-col">
           <Header />
-          <main className="flex-grow">
-            {children}
-          </main>
+          <main className="flex-grow">{children}</main>
           <Footer />
         </div>
       </body>
     </html>
-  )
+  );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,39 +1,48 @@
-import Link from 'next/link'
-import { ArrowRight, BookOpen, Zap, FileText, Users, Calendar, Clock, Tag } from 'lucide-react'
-import { getAllPosts } from '@/lib/blog'
+import Link from "next/link";
+import {
+  ArrowRight,
+  BookOpen,
+  Zap,
+  FileText,
+  Users,
+  Calendar,
+  Clock,
+  Tag,
+} from "lucide-react";
+import { getAllPosts } from "@/lib/blog";
 
 export default function HomePage() {
-  const posts = getAllPosts().slice(0, 3) // 最新3件を表示
-  
+  const posts = getAllPosts().slice(0, 3); // 最新3件を表示
+
   const features = [
     {
       icon: <Zap className="h-8 w-8 text-blue-600" />,
-      title: 'DX推進',
-      description: '自治体のデジタル変革を実践的にサポート',
-      href: '/dx'
+      title: "DX推進",
+      description: "自治体のデジタル変革を実践的にサポート",
+      href: "/dx",
     },
     {
       icon: <FileText className="h-8 w-8 text-green-600" />,
-      title: '条例改正',
-      description: '条例・要綱改正の実務ノウハウを提供',
-      href: '/regulations'
+      title: "条例改正",
+      description: "条例・要綱改正の実務ノウハウを提供",
+      href: "/regulations",
     },
     {
       icon: <Users className="h-8 w-8 text-purple-600" />,
-      title: '契約知識',
-      description: '自治体契約・入札に関する専門知識',
-      href: '/contracts'
+      title: "契約知識",
+      description: "自治体契約・入札に関する専門知識",
+      href: "/contracts",
     },
     {
       icon: <BookOpen className="h-8 w-8 text-orange-600" />,
-      title: 'ブログ',
-      description: '最新の業務効率化情報をお届け',
-      href: '/blog'
-    }
-  ]
+      title: "ブログ",
+      description: "最新の業務効率化情報をお届け",
+      href: "/blog",
+    },
+  ];
 
   return (
-    <div className="bg-white">
+    <div className="bg-white dark:bg-gray-900">
       {/* ヒーローセクション */}
       <section className="bg-gradient-to-br from-blue-900 via-blue-800 to-blue-700 text-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24">
@@ -71,28 +80,26 @@ export default function HomePage() {
       <section className="py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-gray-900 mb-4">
+            <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">
               専門分野
             </h2>
-            <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+            <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
               実務経験に基づいた4つの専門分野で、あなたの業務をサポートします
             </p>
           </div>
-          
+
           <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-8">
             {features.map((feature, index) => (
               <Link
                 key={index}
                 href={feature.href}
-                className="group bg-white p-6 rounded-xl shadow-md hover:shadow-lg transition-all duration-300 border border-gray-100"
+                className="group bg-white p-6 rounded-xl shadow-md hover:shadow-lg transition-all duration-300 border border-gray-100 dark:bg-gray-800 dark:border-gray-700"
               >
-                <div className="mb-4">
-                  {feature.icon}
-                </div>
-                <h3 className="text-xl font-semibold mb-2 text-gray-900 group-hover:text-blue-600 transition-colors">
+                <div className="mb-4">{feature.icon}</div>
+                <h3 className="text-xl font-semibold mb-2 text-gray-900 dark:text-gray-100 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition-colors">
                   {feature.title}
                 </h3>
-                <p className="text-gray-600">
+                <p className="text-gray-600 dark:text-gray-300">
                   {feature.description}
                 </p>
               </Link>
@@ -105,41 +112,47 @@ export default function HomePage() {
       <section className="py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-gray-900 mb-4">
+            <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">
               最新記事
             </h2>
-            <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+            <p className="text-lg text-gray-600 dark:text-gray-300 max-w-2xl mx-auto">
               DX・業務効率化に関する最新の実践情報をお届けします
             </p>
           </div>
 
           {posts.length === 0 ? (
             <div className="text-center py-12">
-              <p className="text-gray-500 text-lg">
+              <p className="text-gray-500 dark:text-gray-400 text-lg">
                 記事はまだありません。最初の記事をお楽しみに！
               </p>
             </div>
           ) : (
             <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8 mb-12">
               {posts.map((post) => (
-                <article key={post.slug} className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300">
+                <article
+                  key={post.slug}
+                  className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow duration-300 dark:bg-gray-800"
+                >
                   <div className="p-6">
-                    <h3 className="text-xl font-bold mb-2 line-clamp-2 text-gray-900">
-                      <Link href={`/blog/${post.slug}`} className="hover:text-blue-600 transition-colors">
+                    <h3 className="text-xl font-bold mb-2 line-clamp-2 text-gray-900 dark:text-gray-100">
+                      <Link
+                        href={`/blog/${post.slug}`}
+                        className="hover:text-blue-600 dark:hover:text-blue-400 transition-colors"
+                      >
                         {post.title}
                       </Link>
                     </h3>
-                    
-                    <p className="text-gray-600 mb-4 line-clamp-3">
+
+                    <p className="text-gray-600 dark:text-gray-300 mb-4 line-clamp-3">
                       {post.excerpt}
                     </p>
-                    
-                    <div className="flex items-center justify-between text-sm text-gray-500 mb-4">
+
+                    <div className="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400 mb-4">
                       <div className="flex items-center gap-4">
                         <div className="flex items-center gap-1">
                           <Calendar size={16} />
                           <time dateTime={post.date}>
-                            {new Date(post.date).toLocaleDateString('ja-JP')}
+                            {new Date(post.date).toLocaleDateString("ja-JP")}
                           </time>
                         </div>
                         <div className="flex items-center gap-1">
@@ -148,12 +161,12 @@ export default function HomePage() {
                         </div>
                       </div>
                     </div>
-                    
+
                     <div className="flex gap-2 flex-wrap">
                       {post.tags.map((tag) => (
                         <span
                           key={tag}
-                          className="inline-flex items-center gap-1 px-3 py-1 bg-blue-50 text-blue-700 rounded-full text-sm"
+                          className="inline-flex items-center gap-1 px-3 py-1 bg-blue-50 text-blue-700 rounded-full text-sm dark:bg-blue-900 dark:text-blue-300"
                         >
                           <Tag size={12} />
                           {tag}
@@ -179,12 +192,12 @@ export default function HomePage() {
       </section>
 
       {/* CTA セクション */}
-      <section className="bg-gray-50 py-16">
+      <section className="bg-gray-50 dark:bg-gray-800 py-16">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl font-bold text-gray-900 mb-4">
+          <h2 className="text-3xl font-bold text-gray-900 dark:text-gray-100 mb-4">
             最新情報をお届けします
           </h2>
-          <p className="text-lg text-gray-600 mb-8 max-w-2xl mx-auto">
+          <p className="text-lg text-gray-600 dark:text-gray-300 mb-8 max-w-2xl mx-auto">
             DX・業務効率化の実践的なノウハウを定期的に配信しています
           </p>
           <Link
@@ -197,5 +210,5 @@ export default function HomePage() {
         </div>
       </section>
     </div>
-  )
+  );
 }


### PR DESCRIPTION
## Summary
- add gradient header and footer with dark theme support
- style cards and prose for readability in dark mode
- apply light/dark color scheme across home page sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897c0a56adc8323bb0c039c898938a0